### PR TITLE
fix cached lookup and implement `GetAttr`, `SetAttr`, `Symlink`

### DIFF
--- a/nfs/file.go
+++ b/nfs/file.go
@@ -81,14 +81,7 @@ func (f *File) Read(p []byte) (int, error) {
 }
 
 func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
-	n, err = f.readAt(p, int64(f.curr))
-	if err != nil {
-		return
-	}
-	if n < len(p) {
-		err = io.EOF
-	}
-	return
+	return f.readAt(p, int64(f.curr))
 }
 
 func (f *File) readAt(p []byte, off int64) (n int, err error) {

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -192,7 +192,7 @@ func (e *EntryPlus) Sys() interface{} {
 		return 0
 	}
 
-	return e.FileId
+	return &e.Attr.Attr
 }
 
 type WccData struct {

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -18,12 +18,14 @@ const (
 
 	// program methods
 	NFSProc3GetAttr     = 1
+	NFSProc3SetAttr     = 2
 	NFSProc3Lookup      = 3
 	NFSProc3Readlink    = 5
 	NFSProc3Read        = 6
 	NFSProc3Write       = 7
 	NFSProc3Create      = 8
 	NFSProc3Mkdir       = 9
+	NFSProc3Symlink     = 10
 	NFSProc3Remove      = 12
 	NFSProc3RmDir       = 13
 	NFSProc3Rename      = 14

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -1,6 +1,5 @@
 // Copyright © 2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
-//
 package nfs
 
 import (
@@ -18,6 +17,7 @@ const (
 	Nfs3Vers = 3
 
 	// program methods
+	NFSProc3GetAttr     = 1
 	NFSProc3Lookup      = 3
 	NFSProc3Readlink    = 5
 	NFSProc3Read        = 6

--- a/nfs/target.go
+++ b/nfs/target.go
@@ -847,7 +847,7 @@ func (v *Target) symlink(srcPath string, fhDst []byte, dst string) error {
 			Rpcvers: 2,
 			Prog:    Nfs3Prog,
 			Vers:    Nfs3Vers,
-			Proc:    NFSProc3Rename,
+			Proc:    NFSProc3Symlink,
 			Cred:    v.auth,
 			Verf:    rpc.AuthNull,
 		},

--- a/nfs/target.go
+++ b/nfs/target.go
@@ -154,7 +154,7 @@ func (v *Target) Lookup(p string, cached ...bool) (os.FileInfo, []byte, error) {
 			dirent = "."
 		}
 
-		if len(cached) > 1 && cached[0] {
+		if len(cached) > 0 && cached[0] {
 			fattr, fh, err = v.cachedLookup(fh, dirent)
 		} else {
 			fattr, fh, err = v.lookup(fh, dirent)


### PR DESCRIPTION
Refer to this [issue](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=57696), renaming files in a directory during a `readdir` operation may cause the read entries loss. 

In our `cachedLookup`, we should ensure the cached entries are complete, so we should check if the `mtime` changes during `readdir`.